### PR TITLE
fix: rename load check in configuration

### DIFF
--- a/private-testnet.yaml
+++ b/private-testnet.yaml
@@ -54,7 +54,7 @@ bee-configs:
     _inherit: "default"
 
 checks:
-  load:
+  load-private-testnet:
     options:
       content-size: 50000000
       postage-amount: 50000000

--- a/testnet.yaml
+++ b/testnet.yaml
@@ -35,7 +35,7 @@ bee-configs:
     bootnodes: "/dnsaddr/testnet.ethswarm.org"
 
 checks:
-  load:
+  load-testnet:
     options:
       content-size: 50000000
       postage-amount: 50000000


### PR DESCRIPTION
- Configuration should not have 2 checks with the same name.
- Load check in testnet.yaml renamed to **load-testnet**.  This check should be started with usage of next flag: **--checks=load-testnet**.
- Load check in private-testnet.yaml renamed to **load-private-testnet**.  This check should be started with usage of next flag: **--checks=load-private-testnet**.